### PR TITLE
Fix Materials.cc when scaling scint pdf

### DIFF
--- a/src/geo/src/Materials.cc
+++ b/src/geo/src/Materials.cc
@@ -460,6 +460,7 @@ G4MaterialPropertyVector *Materials::LoadProperty(DBLinkPtr table, std::string n
       if (E_value != 0.0) {
         double lam = E_value;
         E_value = CLHEP::twopi * CLHEP::hbarc / (lam * CLHEP::nanometer);
+        if (wavelength_opt == 1) p_value *= 1.0 / (E_value * E_value);
         if (wavelength_opt == 2) p_value *= lam / E_value;
       } else {
         warn << "Materials property std::vector zero wavelength!" << newline;


### PR DESCRIPTION
When transforming a ratdb entry describing the scintillation or wavelength shifting pdf as a function of wavelength to energy for sampling, the jacobian element hc/E^2 was omitted causing there to be an unphysical distortion in the output spectrum.  This transformation is now implemented